### PR TITLE
[IT-3428] Dependabot alerts for cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-cryptography~=3.4.8
-pyjwt~=2.8.0
+pyjwt[crypto]~=2.8.0
 requests~=2.31.0
 boto3~=1.34.15
 cachetools~=5.3.2


### PR DESCRIPTION
Instead of managing which version of cryptography to install alongside pyjwt, 
install it as an extra from pyjwt:
https://pyjwt.readthedocs.io/en/stable/installation.html#cryptographic-dependencies-optional