### PR TITLE
IT-3421: Add vulnerability scanning to repo

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -55,6 +55,7 @@ jobs:
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
+      tarfile_artifact: ${{ env.TARFILE_ARTIFACT }}
 
   trivy-scan:
     needs: build
@@ -62,7 +63,7 @@ jobs:
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
       SOURCE_TYPE: tar
-      SOURCE_REF: ${{ env.TARFILE_ARTIFACT }}
+      SOURCE_REF: ${{ needs.build.outputs.tarfile_artifact }}
       EXIT_CODE: 1
 
   push-image:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -39,13 +39,13 @@ jobs:
       - name: Define tags
         id: tags
         run: |
+          echo "mm=${{ steps.version.outputs.is-semver && format('{0}.{1}',
+             steps.version.outputs.major, steps.version.outputs.minor) ||
+             steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
           echo "mmp=${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}',
              steps.version.outputs.major, steps.version.outputs.minor,
              steps.version.outputs.patch) || steps.meta.outputs.tags }}"
              >> $GITHUB_OUTPUT
-          echo "mm=${{ steps.version.outputs.is-semver && format('{0}.{1}',
-             steps.version.outputs.major, steps.version.outputs.minor) ||
-             steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
 
       - name: Build Docker image for scanning (but don't push yet)
         uses: docker/build-push-action@v6.4.0
@@ -90,7 +90,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Define tags # TODO remove this step
+      - name: Show tags # TODO remove this step
         id: check-tags
         run: |
           echo "mmp=" ${{ steps.tags.outputs.mmp }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -53,6 +53,7 @@ jobs:
           # 'imageid' refers to output of previous ('build') step
           image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
+          secret-config: '.trivy-secret.yaml'
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # only output findings for configured severities
           limit-severities-for-sarif: true

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,4 +1,9 @@
 ---
+#
+# This workflow builds a Docker image and passes it to Trivy for
+# vulnerability scanning, only publishing it to ghrc.io if
+# the scan passes.
+#
 name: Build and publish a Docker image
 
 on:
@@ -33,14 +38,13 @@ jobs:
             type=semver,pattern={{version}} # major.minor.patch
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Build Docker image for scanning, but don't push to GHCR yet
+      - name: Build Docker image for scanning, but don't push to ghcr.io yet
         uses: docker/build-push-action@v6.4.0
         id: build
         with:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
-          load: true
           outputs: type=tar,dest=${{ env.TARFILE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -53,7 +57,6 @@ jobs:
 
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
-      labels: ${{ steps.meta.outputs.labels }}
       tarfile_artifact: ${{ env.TARFILE_NAME }}
 
   trivy-scan:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -44,8 +44,8 @@ jobs:
              steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
           echo "mmp=${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}',
              steps.version.outputs.major, steps.version.outputs.minor,
-             steps.version.outputs.patch) || steps.meta.outputs.tags }}"
-             >> $GITHUB_OUTPUT
+             steps.version.outputs.patch) || 
+             steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
 
       - name: Build Docker image for scanning (but don't push yet)
         uses: docker/build-push-action@v6.4.0
@@ -93,8 +93,10 @@ jobs:
       - name: Show tags # TODO remove this step
         id: check-tags
         run: |
-          echo "mmp=" ${{ steps.tags.outputs.mmp }}
-          echo "mm=" ${{ steps.tags.outputs.mm }}
+          echo "mmp="${{ steps.tags.outputs.mmp }}
+          echo "mm="${{ steps.tags.outputs.mm }}
+          echo "All env:"
+          cat $GITHUB_OUTPUT
 
       - name: Push Docker image
         # Note: As explained in

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -13,7 +13,7 @@ env:
   IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
 
 jobs:
-  build-and-push-image:
+  build-scan-and-push-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,6 +22,49 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Mandatory to use the extract version from tag action
+
+      - name: Extract version from tag
+        id: version
+        uses: damienaicheh/extract-version-from-tag-action@v1.3.0
+
+      - name: Build Docker image for scanning (but don't push yet)
+        uses: docker/build-push-action@v6.4.0
+        id: build
+        with:
+          context: .
+          build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
+          push: false
+          load: true
+          tags: |
+            ${{ steps.version.outputs.major }}.\
+              ${{ steps.version.outputs.minor }}.\
+              ${{ steps.version.outputs.patch }}
+            ${{ steps.version.outputs.major }}.\
+              ${{ steps.version.outputs.minor }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          # 'imageid' refers to output of previous ('build') step
+          image-ref: ${{ steps.build.outputs.imageid }}
+          format: 'sarif'
+          exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        # This is the recommended way to upload scan results
+        # after Trivy exits with HIGH/CRITICAL findings
+        # See https://github.com/aquasecurity/trivy-action?\
+        # tab=readme-ov-file#using-trivy-with-github-code-scanning
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: Git Repository
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2.1.0
@@ -36,12 +79,24 @@ jobs:
         with:
           images: ${{ env.IMAGE_PATH }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3.2.0
+      - name: Push Docker image
+        # Note: As explained in
+        # https://docs.docker.com/build/ci/github-actions/test-before-push/
+        # The image is only built once in this workflow.
+        # The image is built once [in the 'build' step],
+        # and [this step uses] the internal cache from the [earlier] step.
+        uses: docker/build-push-action@v6.4.0
         with:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.version.outputs.major }}.\
+              ${{ steps.version.outputs.minor }}.\
+              ${{ steps.version.outputs.patch }}
+            ${{ steps.version.outputs.major }}.\
+              ${{ steps.version.outputs.minor }}
           labels: ${{ steps.meta.outputs.labels }}
+
+
 ...

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -53,7 +53,9 @@ jobs:
           # 'imageid' refers to output of previous ('build') step
           image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
-          secret-config: '.trivy-secret.yaml'
+          # list files to skip, each with a justification
+          skip-files: |
+            /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by package
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # only output findings for configured severities
           limit-severities-for-sarif: true

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -42,7 +42,7 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
-          outputs: type=osi,dest=${{ env.TARFILE_NAME }}
+          outputs: type=oci,dest=${{ env.TARFILE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -54,7 +54,7 @@ jobs:
     uses: "./.github/workflows/trivy.yml"
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
-      SOURCE_TYPE: 'tar'
+      SOURCE_TYPE: tar
       SOURCE_REF: ${{ env.TAR_PREFIX }}
       EXIT_CODE: 1
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -9,7 +9,6 @@ on:
         type: string
 
 env:
-  REGISTRY: ghcr.io
   IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
 
 jobs:
@@ -18,7 +17,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
 
     steps:
       - name: Checkout repository
@@ -45,41 +43,23 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
+          
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        id: trivy
+        uses: "./.github/workflows/trivy.yml"
+        secrets: inherit
         with:
-          # 'imageid' refers to output of previous ('build') step
-          image-ref: ${{ steps.build.outputs.imageid }}
-          format: 'sarif'
-          # list files to skip, each with a justification
-          skip-files: |
-            /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by package
-          ignore-unfixed: true # skip vul'ns for which there is no fix
-          # only output findings for configured severities
-          limit-severities-for-sarif: true
-          exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
-          output: 'trivy-results-${{ inputs.NOTEBOOK_TYPE }}.sarif'
-          severity: 'HIGH,CRITICAL'
+          NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
+          IMAGE_REF: ${{ steps.build.outputs.imageid }}
+          EXIT_CODE: 1
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3.25.12
-        # This is the recommended way to upload scan results
-        # after Trivy exits with HIGH/CRITICAL findings
-        # See https://github.com/aquasecurity/trivy-action?\
-        # tab=readme-ov-file#using-trivy-with-github-code-scanning
-        if: ${{ success() || steps.trivy.conclusion=='failure' }}
-        with:
-          sarif_file: 'trivy-results-${{ inputs.NOTEBOOK_TYPE }}.sarif'
-          category: ${{ inputs.NOTEBOOK_TYPE }}:${{ steps.meta.outputs.tags }}
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2.1.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: Push Docker image
         # Per https://docs.docker.com/build/ci/github-actions/test-before-push,

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
-  TARFILE_ARTIFACT: ${{ inputs.NOTEBOOK_TYPE }}-image-tarfile
   TARFILE_NAME: ${{ inputs.NOTEBOOK_TYPE }}-image.tar
 
 jobs:
@@ -63,7 +62,8 @@ jobs:
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
       SOURCE_TYPE: tar
-      SOURCE_REF: ${{ needs.build.outputs.tarfile_artifact }}
+      IMAGE_NAME: ${{ needs.build.outputs.tags }}
+      TARFILE_NAME: ${{ needs.build.outputs.tarfile_artifact }}
       EXIT_CODE: 1
 
   push-image:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -89,6 +89,12 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Define tags # TODO remove this step
+        id: check-tags
+        run: |
+          echo "mmp=" ${{ steps.tags.outputs.mmp }}
+          echo "mm=" ${{ steps.tags.outputs.mm }}
 
       - name: Push Docker image
         # Note: As explained in

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -42,7 +42,7 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
-          outputs: type=oci,dest=${{ env.TARFILE_NAME }}
+          outputs: type=tar,dest=${{ env.TARFILE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -56,7 +56,7 @@ jobs:
           # 'imageid' refers to output of previous ('build') step
           image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
-          exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
+          exit-code: 0 # TODO change 0 back to 1 Stop if HIGH or CRITICAL findings occurred
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -45,7 +45,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
-        uses: ".github/workflows/trivy.yml"
+        uses: "./.github/workflows/trivy.yml"
         with:
           NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
           IMAGE_REF: ${{ steps.build.outputs.imageid }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -23,31 +23,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Mandatory to use the extract version from tag action
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:
           images: ${{ env.IMAGE_PATH }}
-
-      - name: Extract version from tag
-        id: version
-        uses: battila7/get-version-action@v2
-
-      - name: Define tags
-        id: tags
-        run: |
-          echo "mm=${{ steps.version.outputs.is-semver && format('{0}.{1}',
-             steps.version.outputs.major, steps.version.outputs.minor) ||
-             steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
-          echo "mmp=${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}',
-             steps.version.outputs.major, steps.version.outputs.minor,
-             steps.version.outputs.patch) ||
-             steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
-
-      - name: Build Docker image for scanning (but don't push yet)
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}} # major.minor.patch
+            type=semver,pattern={{major}}.{{minor}}
+            
+      - name: Build Docker image for scanning, but don't push yet
         uses: docker/build-push-action@v6.4.0
         id: build
         with:
@@ -55,9 +43,7 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
-          tags: |
-            ${{ steps.tags.outputs.mmp }}
-            ${{ steps.tags.outputs.mm }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
@@ -90,18 +76,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Show tags # TODO remove this step
-        id: check-tags
-        run: |
-          echo "mmp="${{ steps.tags.outputs.mmp }}
-          echo "mm="${{ steps.tags.outputs.mm }}
-          echo "All env:"
-          cat $GITHUB_OUTPUT
-
       - name: Push Docker image
-        # Note: As explained in
-        # https://docs.docker.com/build/ci/github-actions/test-before-push/
-        # The image is only built once in this workflow.
+        # Per https://docs.docker.com/build/ci/github-actions/test-before-push,
         # The image is built once [in the 'build' step],
         # and [this step uses] the internal cache from the [earlier] step.
         uses: docker/build-push-action@v6.4.0
@@ -109,10 +85,7 @@ jobs:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: true
-          tags: |
-            ${{ steps.tags.outputs.mmp }}
-            ${{ steps.tags.outputs.mm }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
 
 ...

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -67,7 +67,7 @@ jobs:
       EXIT_CODE: 1
 
   push-image:
-    needs: trivy-scan
+    needs: [build, trivy-scan]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: read
+      security-events: write
 
     steps:
       - name: Checkout repository
@@ -56,8 +58,7 @@ jobs:
           # 'imageid' refers to output of previous ('build') step
           image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
-          # TODO change 0 back to 1
-          exit-code: 0 # Stop if HIGH or CRITICAL findings occurred
+          exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -12,11 +12,10 @@ env:
   IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
 
 jobs:
-  build-scan-and-push-image:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -44,21 +43,33 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Run Trivy vulnerability scanner
-        uses: "./.github/workflows/trivy.yml"
-        with:
-          NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
-          IMAGE_REF: ${{ steps.build.outputs.imageid }}
-          EXIT_CODE: 1
+    outputs:
+      imageid: ${{ steps.build.outputs.imageid }}
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
 
+  trivy-scan:
+    needs: build
+    uses: "./.github/workflows/trivy.yml"
+    with:
+      NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
+      IMAGE_REF: ${{ neeeds.build.outputs.imageid }}
+      EXIT_CODE: 1
 
+  push-image:
+    needs: trivy-scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
 
       - name: Push Docker image
         # Per https://docs.docker.com/build/ci/github-actions/test-before-push,
@@ -69,6 +80,6 @@ jobs:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ needs.build.outputs.tags }}
+          labels: ${{ needs.build.outputs.labels }}
 ...

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -10,7 +10,8 @@ on:
 
 env:
   IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
-  TAR_PREFIX: image
+  TARFILE_ARTIFACT: image_tarfile
+  TARFILE_PATH: /tmp/image.tar
 
 jobs:
   build:
@@ -41,9 +42,15 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
-          outputs: type=tar,dest=/tmp/${{ env.TAR_PREFIX }}.tar
+          outputs: type=tar,dest=${{ env.TARFILE_PATH }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Upload tarball for use by Trivy job
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.TARFILE_ARTIFACT }}
+          path: ${{ env.TARFILE_PATH }}
 
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -55,7 +62,7 @@ jobs:
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
       SOURCE_TYPE: tar
-      SOURCE_REF: $TAR_PREFIX
+      SOURCE_REF: $TARFILE_ARTIFACT
       EXIT_CODE: 1
 
   push-image:
@@ -74,13 +81,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download tar file
+        id: tar-download
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.TAR_PREFIX }}
-          path: /tmp
+          name: ${{ env.TARFILE_ARTIFACT }}
 
       - name: Load image from tar
-        run: docker load --input /tmp/${{ env.TAR_PREFIX }}.tar
+        run: docker load --input ${{ steps.tar-download.outputs.download-path }}
 
       - name: Push Docker image
         # Per https://docs.docker.com/build/ci/github-actions/test-before-push,

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
-          push: true
+          push: false
           load: true
           outputs: type=tar,dest=/tmp/${{ env.TAR_PREFIX }}.tar
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -57,7 +57,8 @@ jobs:
           # 'imageid' refers to output of previous ('build') step
           image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
-          exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
+          # TODO uncomment below
+          # exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Build Docker image for scanning, but don't push to ghcr.io yet
         uses: docker/build-push-action@v6.4.0
-        id: build
         with:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -27,7 +27,11 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        uses: damienaicheh/extract-version-from-tag-action@v1.3.0
+        uses: battila7/get-version-action@v2
+        env:
+          mmp: ${{ is-semver && major . minor . patch || \
+               steps.meta.outputs.tags }}
+          mm: ${{ is-semver && major . minor || steps.meta.outputs.tags }}
 
       - name: Build Docker image for scanning (but don't push yet)
         uses: docker/build-push-action@v6.4.0
@@ -38,11 +42,8 @@ jobs:
           push: false
           load: true
           tags: |
-            ${{ steps.version.outputs.major }}.\
-              ${{ steps.version.outputs.minor }}.\
-              ${{ steps.version.outputs.patch }}
-            ${{ steps.version.outputs.major }}.\
-              ${{ steps.version.outputs.minor }}
+            ${{ env.mmp }}
+            ${{ env.mp }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
@@ -56,7 +57,7 @@ jobs:
           severity: 'HIGH,CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3.25.12
         # This is the recommended way to upload scan results
         # after Trivy exits with HIGH/CRITICAL findings
         # See https://github.com/aquasecurity/trivy-action?\
@@ -91,11 +92,8 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: true
           tags: |
-            ${{ steps.version.outputs.major }}.\
-              ${{ steps.version.outputs.minor }}.\
-              ${{ steps.version.outputs.patch }}
-            ${{ steps.version.outputs.major }}.\
-              ${{ steps.version.outputs.minor }}
+            ${{ env.mmp }}
+            ${{ env.mp }}
           labels: ${{ steps.meta.outputs.labels }}
 
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -18,7 +18,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      actions: read
       security-events: write
 
     steps:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -41,7 +41,7 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
-          outputs: type=docker,dest=${{ env.TARFILE_NAME }}
+          outputs: type=tar,dest=${{ env.TARFILE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -93,6 +93,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout repository
+        # TODO This shouldn't be necessary since we're just pushing the image
+        uses: actions/checkout@v4
+
       - name: Push Docker image
         # Since the image is already built, this step
         # will simply push the image

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -41,7 +41,7 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
-          outputs: type=tar,dest=${{ env.TARFILE_NAME }}
+          outputs: type=docker,dest=${{ env.TARFILE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -82,8 +82,8 @@ jobs:
           path: /tmp
 
       - name: Load Docker image from tar
-        run: cat \
-          ${{ steps.tar-download.outputs.download-path}}/${{ env.TARFILE_NAME}}\
+        run: cat
+          ${{ steps.tar-download.outputs.download-path}}/${{ env.TARFILE_NAME}}
           | docker import - ${{ needs.build.outputs.tags }}
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
+  TAR_PREFIX: image
 
 jobs:
   build:
@@ -32,19 +33,19 @@ jobs:
             type=semver,pattern={{version}} # major.minor.patch
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Build Docker image for scanning, but don't push yet
+      - name: Build Docker image for scanning, but don't push to GHCR yet
         uses: docker/build-push-action@v6.4.0
         id: build
         with:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
-          push: false
+          push: true
           load: true
+          outputs: type=docker,dest=/tmp/${{ env.TAR_PREFIX }}.tar
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
     outputs:
-      imageid: ${{ steps.build.outputs.imageid }}
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
 
@@ -53,7 +54,8 @@ jobs:
     uses: "./.github/workflows/trivy.yml"
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
-      IMAGE_REF: ${{ needs.build.outputs.imageid }}
+      SOURCE_TYPE: 'tar'
+      SOURCE_REF: ${{ env.TAR_PREFIX }}
       EXIT_CODE: 1
 
   push-image:
@@ -70,6 +72,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download tar file
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.TAR_PREFIX }}
+          path: /tmp
+
+      - name: Load image from tar
+        run: docker load --input /tmp/${{ env.TAR_PREFIX }}.tar
 
       - name: Push Docker image
         # Per https://docs.docker.com/build/ci/github-actions/test-before-push,

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -45,7 +45,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
-        uses: "./.github/workflows/trivy.yml"
+        uses: ".github/workflows/trivy.yml"
         with:
           NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
           IMAGE_REF: ${{ steps.build.outputs.imageid }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -34,7 +34,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}} # major.minor.patch
             type=semver,pattern={{major}}.{{minor}}
-            
+
       - name: Build Docker image for scanning, but don't push yet
         uses: docker/build-push-action@v6.4.0
         id: build

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -53,7 +53,7 @@ jobs:
     uses: "./.github/workflows/trivy.yml"
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
-      IMAGE_REF: ${{ neeeds.build.outputs.imageid }}
+      IMAGE_REF: ${{ needs.build.outputs.imageid }}
       EXIT_CODE: 1
 
   push-image:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -55,7 +55,7 @@ jobs:
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
       SOURCE_TYPE: tar
-      SOURCE_REF: ${{ env.TAR_PREFIX }}
+      SOURCE_REF: $TAR_PREFIX
       EXIT_CODE: 1
 
   push-image:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -82,9 +82,9 @@ jobs:
           path: /tmp
 
       - name: Load Docker image from tar
-        run: cat ${{ steps.tar-download.outputs.download-path
-          }}/${{ inputs.TARFILE_NAME
-          }} | docker import - ${{ inputs.IMAGE_NAME }}
+        run: cat \
+          ${{ steps.tar-download.outputs.download-path}}/${{ env.TARFILE_NAME}}\
+          | docker import - ${{ needs.build.outputs.tags }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -42,7 +42,7 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
-          outputs: type=tar,dest=${{ env.TARFILE_NAME }}
+          outputs: type=osi,dest=${{ env.TARFILE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -81,10 +81,6 @@ jobs:
           name: ${{ env.TARFILE_NAME }}
           path: /tmp
 
-      - name: list images
-        # TODO remove this debug step
-        run: docker images
-
       - name: Load Docker image from tar
         run: cat
           ${{ steps.tar-download.outputs.download-path}}/${{ env.TARFILE_NAME}}
@@ -97,22 +93,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout repository
-        # TODO This shouldn't be necessary since we're just pushing the image
-        uses: actions/checkout@v4
-
-      - name: list images again
-        # TODO remove this debug step
-        run: docker images
-
       - name: Push Docker image
-        # Since the image is already built, this step
-        # will simply push the image
-        uses: docker/build-push-action@v6.4.0
-        with:
-          context: .
-          build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
-          push: true
-          tags: ${{ needs.build.outputs.tags }}
-          labels: ${{ needs.build.outputs.labels }}
+        run: docker push ${{ needs.build.outputs.tags }}
 ...

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
-  TARFILE_ARTIFACT: image_tarfile
-  TARFILE_PATH: /tmp/image.tar
+  TARFILE_ARTIFACT: ${{ inputs.NOTEBOOK_TYPE }}-image-tarfile
+  TARFILE_PATH: /tmp/${{ inputs.NOTEBOOK_TYPE }}-image.tar
 
 jobs:
   build:
@@ -62,7 +62,7 @@ jobs:
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
       SOURCE_TYPE: tar
-      SOURCE_REF: $TARFILE_ARTIFACT
+      SOURCE_REF: ${{ env.TARFILE_ARTIFACT }}
       EXIT_CODE: 1
 
   push-image:

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -11,7 +11,7 @@ on:
 env:
   IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
   TARFILE_ARTIFACT: ${{ inputs.NOTEBOOK_TYPE }}-image-tarfile
-  TARFILE_PATH: /tmp/${{ inputs.NOTEBOOK_TYPE }}-image.tar
+  TARFILE_NAME: ${{ inputs.NOTEBOOK_TYPE }}-image.tar
 
 jobs:
   build:
@@ -42,20 +42,20 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
-          outputs: type=tar,dest=${{ env.TARFILE_PATH }}
+          outputs: type=tar,dest=${{ env.TARFILE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Upload tarball for use by Trivy job
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.TARFILE_ARTIFACT }}
-          path: ${{ env.TARFILE_PATH }}
+          name: ${{ env.TARFILE_NAME }}
+          path: ${{ env.TARFILE_NAME }}
 
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
-      tarfile_artifact: ${{ env.TARFILE_ARTIFACT }}
+      tarfile_artifact: ${{ env.TARFILE_NAME }}
 
   trivy-scan:
     needs: build
@@ -85,10 +85,12 @@ jobs:
         id: tar-download
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.TARFILE_ARTIFACT }}
+          name: ${{ env.TARFILE_NAME }}
 
       - name: Load image from tar
-        run: docker load --input ${{ steps.tar-download.outputs.download-path }}
+        run: docker load --input \
+          ${{ steps.tar-download.outputs.download-path }}
+          /${{ env.TARFILE_NAME }}
 
       - name: Push Docker image
         # Per https://docs.docker.com/build/ci/github-actions/test-before-push,

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -41,7 +41,7 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: true
           load: true
-          outputs: type=docker,dest=/tmp/${{ env.TAR_PREFIX }}.tar
+          outputs: type=tar,dest=/tmp/${{ env.TAR_PREFIX }}.tar
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -26,11 +26,17 @@ jobs:
         with:
           fetch-depth: 0  # Mandatory to use the extract version from tag action
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.1.1
+        with:
+          images: ${{ env.IMAGE_PATH }}
+
       - name: Extract version from tag
         id: version
         uses: battila7/get-version-action@v2
 
-      - name: define tags
+      - name: Define tags
         id: tags
         run: |
           echo "mmp=${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}',
@@ -83,12 +89,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4.1.1
-        with:
-          images: ${{ env.IMAGE_PATH }}
 
       - name: Push Docker image
         # Note: As explained in

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -56,7 +56,8 @@ jobs:
           # 'imageid' refers to output of previous ('build') step
           image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
-          exit-code: 0 # TODO change 0 back to 1 Stop if HIGH or CRITICAL findings occurred
+          # TODO change 0 back to 1
+          exit-code: 0 # Stop if HIGH or CRITICAL findings occurred
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -30,24 +30,28 @@ jobs:
         id: version
         uses: battila7/get-version-action@v2
 
+      - name: define tags
+        id: tags
+        run: |
+          echo "mmp=${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}',
+             steps.version.outputs.major, steps.version.outputs.minor,
+             steps.version.outputs.patch) || steps.meta.outputs.tags }}"
+             >> $GITHUB_OUTPUT
+          echo "mm=${{ steps.version.outputs.is-semver && format('{0}.{1}',
+             steps.version.outputs.major, steps.version.outputs.minor) ||
+             steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
+
       - name: Build Docker image for scanning (but don't push yet)
         uses: docker/build-push-action@v6.4.0
         id: build
-        env:
-          mmp: ${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}',
-             steps.version.outputs.major, steps.version.outputs.minor,
-             steps.version.outputs.patch) || steps.meta.outputs.tags }}
-          mm: ${{ steps.version.outputs.is-semver && format('{0}.{1}',
-             steps.version.outputs.major, steps.version.outputs.minor) ||
-             steps.meta.outputs.tags }}
         with:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           load: true
           tags: |
-            ${{ env.mmp }}
-            ${{ env.mp }}
+            ${{ steps.tags.outputs.mmp }}
+            ${{ steps.tags.outputs.mm }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
@@ -98,8 +102,8 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: true
           tags: |
-            ${{ env.mmp }}
-            ${{ env.mp }}
+            ${{ steps.tags.outputs.mmp }}
+            ${{ steps.tags.outputs.mm }}
           labels: ${{ steps.meta.outputs.labels }}
 
 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -53,8 +53,10 @@ jobs:
           # 'imageid' refers to output of previous ('build') step
           image-ref: ${{ steps.build.outputs.imageid }}
           format: 'sarif'
-          # TODO uncomment below
-          # exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
+          ignore-unfixed: true # skip vul'ns for which there is no fix
+          # only output findings for configured severities
+          limit-severities-for-sarif: true
+          exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
 
@@ -66,8 +68,8 @@ jobs:
         # tab=readme-ov-file#using-trivy-with-github-code-scanning
         if: ${{ success() || steps.trivy.conclusion=='failure' }}
         with:
-          sarif_file: 'trivy-results.sarif'
-          category: Git Repository
+          sarif_file: 'trivy-results-${{ inputs.NOTEBOOK_TYPE }}.sarif'
+          category: ${{ inputs.NOTEBOOK_TYPE }}:${{ steps.meta.outputs.tags }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -33,11 +33,11 @@ jobs:
         uses: docker/build-push-action@v6.4.0
         id: build
         env:
-          mmp: ${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}', \
-             steps.version.outputs.major, steps.version.outputs.minor, \
+          mmp: ${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}',
+             steps.version.outputs.major, steps.version.outputs.minor,
              steps.version.outputs.patch) || steps.meta.outputs.tags }}
-          mm: ${{ steps.version.outputs.is-semver && format('{0}.{1}', \
-             steps.version.outputs.major, steps.version.outputs.minor) || \
+          mm: ${{ steps.version.outputs.is-semver && format('{0}.{1}',
+             steps.version.outputs.major, steps.version.outputs.minor) ||
              steps.meta.outputs.tags }}
         with:
           context: .

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -74,6 +74,18 @@ jobs:
       packages: write
 
     steps:
+      - name: Download tar file
+        id: tar-download
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.TARFILE_NAME }}
+          path: /tmp
+
+      - name: Load Docker image from tar
+        run: cat ${{ steps.tar-download.outputs.download-path
+          }}/${{ inputs.TARFILE_NAME
+          }} | docker import - ${{ inputs.IMAGE_NAME }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -81,21 +93,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download tar file
-        id: tar-download
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.TARFILE_NAME }}
-
-      - name: Load image from tar
-        run: docker load --input \
-          ${{ steps.tar-download.outputs.download-path }}
-          /${{ env.TARFILE_NAME }}
-
       - name: Push Docker image
-        # Per https://docs.docker.com/build/ci/github-actions/test-before-push,
-        # The image is built once [in the 'build' step],
-        # and [this step uses] the internal cache from the [earlier] step.
+        # Since the image is already built, this step
+        # will simply push the image
         uses: docker/build-push-action@v6.4.0
         with:
           context: .

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -89,7 +89,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Define tags # TODO remove this step
         id: check-tags
         run: |

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -81,6 +81,10 @@ jobs:
           name: ${{ env.TARFILE_NAME }}
           path: /tmp
 
+      - name: list images
+        # TODO remove this debug step
+        run: docker images
+
       - name: Load Docker image from tar
         run: cat
           ${{ steps.tar-download.outputs.download-path}}/${{ env.TARFILE_NAME}}
@@ -96,6 +100,10 @@ jobs:
       - name: Checkout repository
         # TODO This shouldn't be necessary since we're just pushing the image
         uses: actions/checkout@v4
+
+      - name: list images again
+        # TODO remove this debug step
+        run: docker images
 
       - name: Push Docker image
         # Since the image is already built, this step

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -28,15 +28,17 @@ jobs:
       - name: Extract version from tag
         id: version
         uses: battila7/get-version-action@v2
-        env:
-          mmp: ${{ is-semver && format('{0}.{1}.{2}', major, minor,patch) || \
-             steps.meta.outputs.tags }}
-          mm: ${{ is-semver && format('{0}.{1}', major, minor) || \
-             steps.meta.outputs.tags }}
 
       - name: Build Docker image for scanning (but don't push yet)
         uses: docker/build-push-action@v6.4.0
         id: build
+        env:
+          mmp: ${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}', \
+             steps.version.outputs.major, steps.version.outputs.minor, \
+             steps.version.outputs.patch) || steps.meta.outputs.tags }}
+          mm: ${{ steps.version.outputs.is-semver && format('{0}.{1}', \
+             steps.version.outputs.major, steps.version.outputs.minor) || \
+             steps.meta.outputs.tags }}
         with:
           context: .
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -43,10 +43,9 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          
+
       - name: Run Trivy vulnerability scanner
         uses: "./.github/workflows/trivy.yml"
-        secrets: inherit
         with:
           NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
           IMAGE_REF: ${{ steps.build.outputs.imageid }}
@@ -72,5 +71,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
 ...

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -57,7 +57,7 @@ jobs:
           # only output findings for configured severities
           limit-severities-for-sarif: true
           exit-code: 1 # Stop if HIGH or CRITICAL findings occurred
-          output: 'trivy-results.sarif'
+          output: 'trivy-results-${{ inputs.NOTEBOOK_TYPE }}.sarif'
           severity: 'HIGH,CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -29,9 +29,10 @@ jobs:
         id: version
         uses: battila7/get-version-action@v2
         env:
-          mmp: ${{ is-semver && major . minor . patch || \
-               steps.meta.outputs.tags }}
-          mm: ${{ is-semver && major . minor || steps.meta.outputs.tags }}
+          mmp: ${{ is-semver && format('{0}.{1}.{2}', major, minor,patch) || \
+             steps.meta.outputs.tags }}
+          mm: ${{ is-semver && format('{0}.{1}', major, minor) || \
+             steps.meta.outputs.tags }}
 
       - name: Build Docker image for scanning (but don't push yet)
         uses: docker/build-push-action@v6.4.0
@@ -48,6 +49,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
+        id: trivy
         with:
           # 'imageid' refers to output of previous ('build') step
           image-ref: ${{ steps.build.outputs.imageid }}
@@ -62,7 +64,7 @@ jobs:
         # after Trivy exits with HIGH/CRITICAL findings
         # See https://github.com/aquasecurity/trivy-action?\
         # tab=readme-ov-file#using-trivy-with-github-code-scanning
-        if: always()
+        if: ${{ success() || steps.trivy.conclusion=='failure' }}
         with:
           sarif_file: 'trivy-results.sarif'
           category: Git Repository

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -44,7 +44,7 @@ jobs:
              steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
           echo "mmp=${{ steps.version.outputs.is-semver && format('{0}.{1}.{2}',
              steps.version.outputs.major, steps.version.outputs.minor,
-             steps.version.outputs.patch) || 
+             steps.version.outputs.patch) ||
              steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
 
       - name: Build Docker image for scanning (but don't push yet)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,29 @@ jobs:
       - name: Run unit tests
         run: python -m pytest tests/ -s -v
 
+  trivy:
+    name: Trivy-vulnerability-scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: Git Repository
+
   docker-build-push-jupyter:
     if: ${{ github.event_name == 'push' }}
     needs: [tests]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,30 +33,9 @@ jobs:
       - name: Run unit tests
         run: python -m pytest tests/ -s -v
 
-  trivy:
-    name: Trivy-vulnerability-scan
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'fs'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'LOW,MEDIUM,HIGH,CRITICAL'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: Git Repository
-
   docker-build-push-jupyter:
     if: ${{ github.event_name == 'push' }}
-    needs: [tests, trivy]
+    needs: [tests]
     uses: "./.github/workflows/docker_build_push.yml"
     secrets: inherit
     with:
@@ -64,7 +43,7 @@ jobs:
 
   docker-build-push-rstudio:
     if: ${{ github.event_name == 'push' }}
-    needs: [tests, trivy]
+    needs: [tests]
     uses: "./.github/workflows/docker_build_push.yml"
     secrets: inherit
     with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,11 @@ jobs:
         uses: pre-commit/action@v3.0.0
 
       - name: Build Docker Image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v6.4.0
         with:
           context: .
           build-args: notebook_type=jupyter
+          push: false
 
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
   docker-build-push-jupyter:
     if: ${{ github.event_name == 'push' }}
     needs: [tests]
-    uses: ".github/workflows/docker_build_push.yml"
+    uses: "./.github/workflows/docker_build_push.yml"
     secrets: inherit
     with:
       NOTEBOOK_TYPE: jupyter
@@ -44,7 +44,7 @@ jobs:
   docker-build-push-rstudio:
     if: ${{ github.event_name == 'push' }}
     needs: [tests]
-    uses: ".github/workflows/docker_build_push.yml"
+    uses: "./.github/workflows/docker_build_push.yml"
     secrets: inherit
     with:
       NOTEBOOK_TYPE: rstudio

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
   docker-build-push-jupyter:
     if: ${{ github.event_name == 'push' }}
     needs: [tests]
-    uses: "./.github/workflows/docker_build_push.yml"
+    uses: ".github/workflows/docker_build_push.yml"
     secrets: inherit
     with:
       NOTEBOOK_TYPE: jupyter
@@ -44,7 +44,7 @@ jobs:
   docker-build-push-rstudio:
     if: ${{ github.event_name == 'push' }}
     needs: [tests]
-    uses: "./.github/workflows/docker_build_push.yml"
+    uses: ".github/workflows/docker_build_push.yml"
     secrets: inherit
     with:
       NOTEBOOK_TYPE: rstudio

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,11 +44,9 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'fs'
-          ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          limit-severities-for-sarif: true
+          severity: 'LOW,MEDIUM,HIGH,CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
@@ -58,7 +56,7 @@ jobs:
 
   docker-build-push-jupyter:
     if: ${{ github.event_name == 'push' }}
-    needs: [tests]
+    needs: [tests, trivy]
     uses: "./.github/workflows/docker_build_push.yml"
     secrets: inherit
     with:
@@ -66,7 +64,7 @@ jobs:
 
   docker-build-push-rstudio:
     if: ${{ github.event_name == 'push' }}
-    needs: [tests]
+    needs: [tests, trivy]
     uses: "./.github/workflows/docker_build_push.yml"
     secrets: inherit
     with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,9 +23,10 @@ on:
       IMAGE_NAME:
         required: true
         type: string
-      EXIT_CODE:
+      EXIT_CODE: # return code for failed scan. 0 means OK
         required: false
         type: number
+        default: 0
 
 env:
   sarif_file_name: trivy-results-${{ inputs.NOTEBOOK_TYPE  }}.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -36,9 +36,8 @@ jobs:
           image-ref: ${{ inputs.IMAGE_REF }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
-          # TODO uncomment the following two lines
-          # skip-files: |
-          #   /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by pkg
+          skip-files: |
+            /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by pkg
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           # only output findings for configured severities

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,11 +33,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download tar file
+        id: tar-download
         uses: actions/download-artifact@v4
         if: ${{ inputs.SOURCE_TYPE == 'tar' }}
         with:
           name: ${{ inputs.SOURCE_REF }}
-          path: /tmp
 
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@0.24.0
@@ -46,7 +46,7 @@ jobs:
           image-ref: ${{ inputs.SOURCE_TYPE == 'image' }}
             && ${{ inputs.SOURCE_REF }}
           input: ${{ inputs.SOURCE_TYPE == 'tar' }}
-            && ${{ inputs.SOURCE_REF }}
+            && ${{ steps.tar-download.outputs.download-path }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
           # TODO uncomment the following two lines

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner for any major issues
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.24.0
         id: trivy
         with:
           image-ref: ${{ inputs.IMAGE_REF }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,9 @@ jobs:
       security-events: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@master
         id: trivy

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -61,17 +61,18 @@ jobs:
         id: trivy
         with:
           image-ref: ${{ inputs.IMAGE_NAME }}
-          # TODO toggle
-          ignore-unfixed: false # skip vul'ns for which there is no fix
+          ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
-          skip-files: |
-            /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by pkg
+          # TODO uncomment
+          #skip-files: |
+          #  /etc/ssl/private/ssl-cert-snakeoil.key
+          # ssl-cert-snakeoil.key is req'd by the ssl package.
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           # only output findings for configured severities
           limit-severities-for-sarif: true
           output: ${{ env.sarif_file_name  }}
-          exit-code: ${{ env.EXIT_CODE }}
+          exit-code: ${{ inputs.EXIT_CODE }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3.25.12

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -50,8 +50,9 @@ jobs:
 
       - name: load docker image
         if: ${{ inputs.SOURCE_TYPE == 'tar' }}
-        run: docker load --input ${{ steps.tar-download.outputs.download-path
-          }}/${{ inputs.TARFILE_NAME }}
+        run: cat ${{ steps.tar-download.outputs.download-path
+          }}/${{ inputs.TARFILE_NAME
+          }} | docker import - ${{ inputs.IMAGE_NAME }}
 
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@0.24.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -47,10 +47,9 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         id: trivy
         with:
-          image-ref: ${{ inputs.SOURCE_TYPE == 'image' &&
-            inputs.SOURCE_REF || null}}
-          input: ${{ steps.tar-download.outputs.download-path }}
-            /${{ inputs.SOURCE_REF }}
+          # TODO: Fix to support periodic scans
+          input: ${{ steps.tar-download.outputs.download-path
+            }}/${{ inputs.SOURCE_REF }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
           # TODO uncomment the following two lines

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: load docker image
         if: ${{ inputs.SOURCE_TYPE == 'tar' }}
-        run: docker load --input ${{ steps.tar-download.outputs.download-path
+        run: docker import --input ${{ steps.tar-download.outputs.download-path
           }}/${{ inputs.TARFILE_NAME }}
 
       - name: Run Trivy vulnerability scanner for any major issues

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -47,7 +47,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         id: trivy
         with:
-          image-ref: ${{ inputs.SOURCE_TYPE == 'image' && inputs.SOURCE_REF }}
+          image-ref: ${{ inputs.SOURCE_TYPE == 'image' &&
+            inputs.SOURCE_REF || Null}}
           input: ${{ steps.tar-download.outputs.download-path }}
             /${{ inputs.SOURCE_REF }}
           ignore-unfixed: true # skip vul'ns for which there is no fix

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -48,7 +48,7 @@ jobs:
         id: trivy
         with:
           image-ref: ${{ inputs.SOURCE_TYPE == 'image' &&
-            inputs.SOURCE_REF || Null}}
+            inputs.SOURCE_REF || null}}
           input: ${{ steps.tar-download.outputs.download-path }}
             /${{ inputs.SOURCE_REF }}
           ignore-unfixed: true # skip vul'ns for which there is no fix

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,4 +1,11 @@
 ---
+#
+# This workflow runs Trivy on a Docker image
+# It can pull the image from a container registry
+# or download a tar file.  The latter is used
+# to check a container image prior to publishing
+# to the registry.
+
 name: Run Trivy on a Docker image and push results to GitHub
 
 on:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: inspect tar download
         run: ls -al ${{ steps.tar-download.outputs.download-path }}
+          /${{ inputs.SOURCE_REF }}
 
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@0.24.0
@@ -48,6 +49,7 @@ jobs:
         with:
           image-ref: ${{ inputs.SOURCE_TYPE == 'image' && inputs.SOURCE_REF }}
           input: ${{ steps.tar-download.outputs.download-path }}
+            /${{ inputs.SOURCE_REF }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
           # TODO uncomment the following two lines

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,58 @@
+---
+name: Run Trivy on a Docker image and push results to GitHub
+
+on:
+  workflow_call:
+    inputs:
+      NOTEBOOK_TYPE:
+        required: true
+        type: string
+      IMAGE_REF:
+        required: true
+        type: string
+      EXIT_CODE:
+        required: false
+        type: integer
+
+env:
+  sarif_file_name: trivy-results-${{ inputs.NOTEBOOK_TYPE  }}.sarif
+
+jobs:
+  trivy:
+    name: Trivy-${{ inputs.NOTEBOOK_TYPE  }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Run Trivy vulnerability scanner for any major issues
+        id: trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ inputs.IMAGE_REF }}
+          ignore-unfixed: true # skip vul'ns for which there is no fix
+          # list files to skip, each with a justification
+          # TODO uncomment the following two lines
+          # skip-files: |
+          #   /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by package
+          severity: 'CRITICAL,HIGH'
+          format: 'sarif'
+          # only output findings for configured severities
+          limit-severities-for-sarif: true
+          template: '@/contrib/sarif.tpl'
+          output: ${{ env.sarif_file_name  }}
+          exit-code: ${{ env.EXIT_CODE }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3.25.12
+        # This is the recommended way to upload scan results
+        # after Trivy exits with HIGH/CRITICAL findings
+        # See https://github.com/aquasecurity/trivy-action?\
+        # tab=readme-ov-file#using-trivy-with-github-code-scanning
+        if: ${{ success() || steps.trivy.conclusion=='failure' }}
+        with:
+          sarif_file: ${{ env.sarif_file_name  }}
+          category: ${{ inputs.NOTEBOOK_TYPE }}
+          wait-for-processing: true
+...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -61,11 +61,11 @@ jobs:
         id: trivy
         with:
           image-ref: ${{ inputs.IMAGE_NAME }}
-          ignore-unfixed: true # skip vul'ns for which there is no fix
+          # TODO toggle
+          ignore-unfixed: false # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
-          # TODO uncomment the following two lines
-          # skip-files: |
-          #   /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by pkg
+          skip-files: |
+            /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by pkg
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           # only output findings for configured severities

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -63,9 +63,8 @@ jobs:
           image-ref: ${{ inputs.IMAGE_NAME }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
-          # TODO uncomment
-          #skip-files: |
-          #  /etc/ssl/private/ssl-cert-snakeoil.key
+          skip-files: |
+            /etc/ssl/private/ssl-cert-snakeoil.key
           # ssl-cert-snakeoil.key is req'd by the ssl package.
           severity: 'CRITICAL,HIGH'
           format: 'sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,7 +43,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         id: trivy
         with:
-          image-ref: ${{ inputs.SOURCE_TYPE == 'image && inputs.SOURCE_REF }}
+          image-ref: ${{ inputs.SOURCE_TYPE == 'image' && inputs.SOURCE_REF }}
           input: ${{ steps.tar-download.outputs.download-path }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,7 +7,10 @@ on:
       NOTEBOOK_TYPE:
         required: true
         type: string
-      IMAGE_REF:
+      SOURCE_TYPE:
+        required: true
+        type: string
+      SOURCE_REF:
         required: true
         type: string
       EXIT_CODE:
@@ -29,15 +32,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download tar file
+        uses: actions/download-artifact@v4
+        if: ${{ inputs.SOURCE_TYPE == 'tar' }}
+        with:
+          name: ${{ inputs.SOURCE_REF }}
+          path: /tmp
+
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@0.24.0
         id: trivy
         with:
-          image-ref: ${{ inputs.IMAGE_REF }}
+          image-ref: ${{ inputs.SOURCE_TYPE == 'image' }}
+            && ${{ inputs.SOURCE_REF }}
+          input: ${{ inputs.SOURCE_TYPE == 'tar' }}
+            && ${{ inputs.SOURCE_REF }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
-          skip-files: |
-            /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by pkg
+          # TODO uncomment the following two lines
+          # skip-files: |
+          #   /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by pkg
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           # only output findings for configured severities

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,10 +7,13 @@ on:
       NOTEBOOK_TYPE:
         required: true
         type: string
-      SOURCE_TYPE:
+      SOURCE_TYPE: # 'tar' or 'image'
         required: true
         type: string
-      SOURCE_REF:
+      TARFILE_NAME: # only used if SOURCE_TYPE=='tar'
+        required: false
+        type: string
+      IMAGE_NAME:
         required: true
         type: string
       EXIT_CODE:
@@ -37,19 +40,23 @@ jobs:
         uses: actions/download-artifact@v4
         if: ${{ inputs.SOURCE_TYPE == 'tar' }}
         with:
-          name: ${{ inputs.SOURCE_REF }}
+          name: ${{ inputs.TARFILE_NAME }}
 
       - name: inspect tar download
+        if: ${{ inputs.SOURCE_TYPE == 'tar' }}
         run: ls -al ${{ steps.tar-download.outputs.download-path
-          }}/${{ inputs.SOURCE_REF }}
+          }}/${{ inputs.TARFILE_NAME }}
+
+      - name: load docker image
+        if: ${{ inputs.SOURCE_TYPE == 'tar' }}
+        run: docker load --input ${{ steps.tar-download.outputs.download-path
+          }}/${{ inputs.TARFILE_NAME }}
 
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@0.24.0
         id: trivy
         with:
-          # TODO: Fix to support periodic scans
-          input: ${{ steps.tar-download.outputs.download-path
-            }}/${{ inputs.SOURCE_REF }}
+          image-ref: ${{ inputs.IMAGE_NAME }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
           # TODO uncomment the following two lines

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           name: ${{ inputs.SOURCE_REF }}
 
+      - name: inspect tar download
+        run: ls -al ${{ steps.tar-download.outputs.download-path }}
+
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@0.24.0
         id: trivy
@@ -54,7 +57,6 @@ jobs:
           format: 'sarif'
           # only output findings for configured severities
           limit-severities-for-sarif: true
-          template: '@/contrib/sarif.tpl'
           output: ${{ env.sarif_file_name  }}
           exit-code: ${{ env.EXIT_CODE }}
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -41,6 +41,7 @@ jobs:
         if: ${{ inputs.SOURCE_TYPE == 'tar' }}
         with:
           name: ${{ inputs.TARFILE_NAME }}
+          path: /tmp
 
       - name: inspect tar download
         if: ${{ inputs.SOURCE_TYPE == 'tar' }}
@@ -49,7 +50,7 @@ jobs:
 
       - name: load docker image
         if: ${{ inputs.SOURCE_TYPE == 'tar' }}
-        run: docker import --input ${{ steps.tar-download.outputs.download-path
+        run: docker load --input ${{ steps.tar-download.outputs.download-path
           }}/${{ inputs.TARFILE_NAME }}
 
       - name: Run Trivy vulnerability scanner for any major issues

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,8 +40,8 @@ jobs:
           name: ${{ inputs.SOURCE_REF }}
 
       - name: inspect tar download
-        run: ls -al ${{ steps.tar-download.outputs.download-path }}
-          /${{ inputs.SOURCE_REF }}
+        run: ls -al ${{ steps.tar-download.outputs.download-path
+          }}/${{ inputs.SOURCE_REF }}
 
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@0.24.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,12 +43,7 @@ jobs:
           name: ${{ inputs.TARFILE_NAME }}
           path: /tmp
 
-      - name: inspect tar download
-        if: ${{ inputs.SOURCE_TYPE == 'tar' }}
-        run: ls -al ${{ steps.tar-download.outputs.download-path
-          }}/${{ inputs.TARFILE_NAME }}
-
-      - name: load docker image
+      - name: load docker image from tar file
         if: ${{ inputs.SOURCE_TYPE == 'tar' }}
         run: cat ${{ steps.tar-download.outputs.download-path
           }}/${{ inputs.TARFILE_NAME

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,10 +43,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         id: trivy
         with:
-          image-ref: ${{ inputs.SOURCE_TYPE == 'image'
-            && inputs.SOURCE_REF }}
-          input: ${{ inputs.SOURCE_TYPE == 'tar'
-            && steps.tar-download.outputs.download-path }}
+          image-ref: ${{ inputs.SOURCE_TYPE == 'image && inputs.SOURCE_REF }}
+          input: ${{ steps.tar-download.outputs.download-path }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
           # TODO uncomment the following two lines

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,10 +43,10 @@ jobs:
         uses: aquasecurity/trivy-action@0.24.0
         id: trivy
         with:
-          image-ref: ${{ inputs.SOURCE_TYPE == 'image' }}
-            && ${{ inputs.SOURCE_REF }}
-          input: ${{ inputs.SOURCE_TYPE == 'tar' }}
-            && ${{ steps.tar-download.outputs.download-path }}
+          image-ref: ${{ inputs.SOURCE_TYPE == 'image'
+            && inputs.SOURCE_REF }}
+          input: ${{ inputs.SOURCE_TYPE == 'tar'
+            && steps.tar-download.outputs.download-path }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
           # TODO uncomment the following two lines

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,7 +12,7 @@ on:
         type: string
       EXIT_CODE:
         required: false
-        type: integer
+        type: number
 
 env:
   sarif_file_name: trivy-results-${{ inputs.NOTEBOOK_TYPE  }}.sarif
@@ -27,15 +27,15 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner for any major issues
-        id: trivy
         uses: aquasecurity/trivy-action@master
+        id: trivy
         with:
           image-ref: ${{ inputs.IMAGE_REF }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
           # list files to skip, each with a justification
           # TODO uncomment the following two lines
           # skip-files: |
-          #   /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by package
+          #   /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by pkg
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           # only output findings for configured severities

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -1,4 +1,10 @@
 ---
+#
+# This workflow scans the published container images
+# for new vulnerabilities daily, publishing findings.
+# Findings will be associated with the 'main' branch
+# of the repo' in the GitHub Security tab.
+#
 name: Trivy Periodic Image Scan
 
 on:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -3,8 +3,8 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
-    # each five minutes
-    - cron: "*/5 * * * *"
+    # each hour
+    - cron: "* */1 * * *"
     # TODO change to daily
     # - cron: "0 0 * * *"
 

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -3,8 +3,8 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
-    # each hour
-    - cron: "* */1 * * *"
+    # 15 minutes after each hour
+    - cron: "15 * * * *"
     # TODO change to daily
     # - cron: "0 0 * * *"
 
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.notebook_type }}
     runs-on: ubuntu-latest
     env:
-      branch: main
+      branch: IT-3421 # TODO change back to 'main' before creating a PR
     strategy:
       matrix:
         notebook_type:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -9,7 +9,7 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
-    # at the top of each hour (for testing)
+    # run daily
     - cron: "0 0 * * *"
 
 jobs:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -19,7 +19,7 @@ jobs:
     uses: "./.github/workflows/trivy.yml"
     with:
       NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
-      SOURCE_TYPE: 'image'
-      SOURCE_REF: ghcr.io/${{ github.repository }}-\
+      SOURCE_TYPE: image
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-\
             ${{ matrix.notebook_type }}:main
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -1,0 +1,48 @@
+name: Trivy Periodic Image Scan
+
+on:
+  schedule:
+    # each five minutes
+    - cron: "*/5 * * * *"
+    # TODO change to daily
+    # - cron: "0 0 * * *"
+
+jobs:
+  trivy:
+    name: ${{ matrix.notebook_type }}
+    runs-on: ubuntu-latest
+    env:
+      branch: main
+    strategy:
+      matrix:
+        notebook_type:
+          - jupyter
+          - rstudio
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner for any major issues
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/${{ github.repository }}-\
+            ${{ matrix.notebook_type }}:${{ env.branch }}
+          ignore-unfixed: true # skip vul'ns for which there is no fix
+          severity: 'CRITICAL,HIGH'
+          format: 'sarif'
+          # only output findings for configured severities
+          limit-severities-for-sarif: true
+          template: '@/contrib/sarif.tpl'
+          output: trivy-results-periodic-${{ matrix.notebook_type }}.sarif
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-results-${{ matrix.notebook_type }}.sarif
+          category: ${{ matrix.notebook_type }}:${{ env.branch }}
+          wait-for-processing: true

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -1,3 +1,4 @@
+---
 name: Trivy Periodic Image Scan
 
 on:
@@ -46,3 +47,4 @@ jobs:
           sarif_file: trivy-results-periodic-${{ matrix.notebook_type }}.sarif
           category: ${{ matrix.notebook_type }}:${{ env.branch }}
           wait-for-processing: true
+...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -19,6 +19,7 @@ jobs:
     uses: "./.github/workflows/trivy.yml"
     with:
       NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
-      IMAGE_REF: ghcr.io/${{ github.repository }}-\
+      SOURCE_TYPE: 'image'
+      SOURCE_REF: ghcr.io/${{ github.repository }}-\
             ${{ matrix.notebook_type }}:main
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -20,6 +20,6 @@ jobs:
     with:
       NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
       SOURCE_TYPE: image
-      IMAGE_NAME: ghcr.io/${{ github.repository }}-\
-            ${{ matrix.notebook_type }}:main
+      IMAGE_NAME: ghcr.io/${{ github.repository
+        }}-${{ matrix.notebook_type }}:main
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -3,8 +3,8 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
-    # 15 minutes after each hour
-    - cron: "15 * * * *"
+    # at the top of each hour (for testing)
+    - cron: "0 * * * *"
     # TODO change to daily
     # - cron: "0 0 * * *"
 
@@ -12,42 +12,15 @@ jobs:
   trivy:
     name: ${{ matrix.notebook_type }}
     runs-on: ubuntu-latest
-    env:
-      branch: IT-3421 # TODO change back to 'main' before creating a PR
     strategy:
       matrix:
         notebook_type:
           - jupyter
           - rstudio
-
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Trivy vulnerability scanner for any major issues
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/${{ github.repository }}-\
-            ${{ matrix.notebook_type }}:${{ env.branch }}
-          ignore-unfixed: true # skip vul'ns for which there is no fix
-          # list files to skip, each with a justification
-          skip-files: |
-            /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by package
-          severity: 'CRITICAL,HIGH'
-          format: 'sarif'
-          # only output findings for configured severities
-          limit-severities-for-sarif: true
-          template: '@/contrib/sarif.tpl'
-          output: trivy-results-periodic-${{ matrix.notebook_type }}.sarif
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: trivy-results-periodic-${{ matrix.notebook_type }}.sarif
-          category: ${{ matrix.notebook_type }}:${{ env.branch }}
-          wait-for-processing: true
+    uses: "./.github/workflows/trivy.yml"
+    secrets: inherit
+    with:
+      NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
+      IMAGE_REF: ghcr.io/${{ github.repository }}-\
+        ${{ matrix.notebook_type }}:main
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -19,7 +19,7 @@ jobs:
           - rstudio
     steps:
       - name: trivy
-        uses: ".github/workflows/trivy.yml"
+        uses: "./.github/workflows/trivy.yml"
         with:
           NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
           IMAGE_REF: ghcr.io/${{ github.repository }}-\

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -34,7 +34,9 @@ jobs:
           image-ref: ghcr.io/${{ github.repository }}-\
             ${{ matrix.notebook_type }}:${{ env.branch }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
-          secret-config: '.trivy-secret.yaml'
+          # list files to skip, each with a justification
+          skip-files: |
+            /etc/ssl/private/ssl-cert-snakeoil.key # secret is req'd by package
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           # only output findings for configured severities

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -19,7 +19,7 @@ jobs:
           - rstudio
     steps:
       - name: trivy
-        uses: "./.github/workflows/trivy.yml"
+        uses: ".github/workflows/trivy.yml"
         with:
           NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
           IMAGE_REF: ghcr.io/${{ github.repository }}-\

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -11,17 +11,14 @@ on:
 jobs:
   trivy-matrix:
     name: ${{ matrix.notebook_type }}
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         notebook_type:
           - jupyter
           - rstudio
-    steps:
-      - name: trivy
-        uses: "./.github/workflows/trivy.yml"
-        with:
-          NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
-          IMAGE_REF: ghcr.io/${{ github.repository }}-\
+    uses: "./.github/workflows/trivy.yml"
+    with:
+      NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
+      IMAGE_REF: ghcr.io/${{ github.repository }}-\
             ${{ matrix.notebook_type }}:main
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -43,6 +43,6 @@ jobs:
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: trivy-results-${{ matrix.notebook_type }}.sarif
+          sarif_file: trivy-results-periodic-${{ matrix.notebook_type }}.sarif
           category: ${{ matrix.notebook_type }}:${{ env.branch }}
           wait-for-processing: true

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -9,7 +9,7 @@ on:
     # - cron: "0 0 * * *"
 
 jobs:
-  trivy:
+  trivy-matrix:
     name: ${{ matrix.notebook_type }}
     runs-on: ubuntu-latest
     strategy:
@@ -17,10 +17,11 @@ jobs:
         notebook_type:
           - jupyter
           - rstudio
-    uses: "./.github/workflows/trivy.yml"
-    secrets: inherit
-    with:
-      NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
-      IMAGE_REF: ghcr.io/${{ github.repository }}-\
-        ${{ matrix.notebook_type }}:main
+    steps:
+      - name: trivy
+        uses: "./.github/workflows/trivy.yml"
+        with:
+          NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
+          IMAGE_REF: ghcr.io/${{ github.repository }}-\
+            ${{ matrix.notebook_type }}:main
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -34,6 +34,7 @@ jobs:
           image-ref: ghcr.io/${{ github.repository }}-\
             ${{ matrix.notebook_type }}:${{ env.branch }}
           ignore-unfixed: true # skip vul'ns for which there is no fix
+          secret-config: '.trivy-secret.yaml'
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           # only output findings for configured severities

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -10,9 +10,7 @@ name: Trivy Periodic Image Scan
 on:
   schedule:
     # at the top of each hour (for testing)
-    - cron: "0 * * * *"
-    # TODO change to daily
-    # - cron: "0 0 * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   trivy-matrix:

--- a/.trivy-secret.yaml
+++ b/.trivy-secret.yaml
@@ -1,0 +1,6 @@
+# List of secrets checks to suppress
+# Each suppression requires a justification. (Place in the 'description'.)
+allow-rules:
+  - id: allow-snakeoil-private-key
+    description: snakeoil requires a private key
+    path: /etc/ssl/private/ssl-cert-snakeoil.key

--- a/.trivy-secret.yaml
+++ b/.trivy-secret.yaml
@@ -1,6 +1,0 @@
-# List of secrets checks to suppress
-# Each suppression requires a justification. (Place in the 'description'.)
-allow-rules:
-  - id: allow-snakeoil-private-key
-    description: snakeoil requires a private key
-    path: /etc/ssl/private/ssl-cert-snakeoil.key

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,12 @@
+#
+# List vulnerabilities flagged by Trivy but for which
+# the affected code is not used or the risk is acceptable.
+# Enter the ID of the vulnerability along with the
+# justification as comment, for example:
+#
+# # Accept the risk
+# CVE-2018-14618
+#
+# More here:
+# https://aquasecurity.github.io/trivy/v0.22.0/vulnerability/examples/filter/
+#

--- a/README.md
+++ b/README.md
@@ -103,3 +103,20 @@ docker run -d --name ${NOTEBOOK_CONTAINER_NAME} \
 ${DOCKER_IMAGE}
 
 ```
+
+
+## Security
+
+Trivy is run on each built container, to scan for known vulnerabilities.
+Containers will not be published to `ghcr.io` if any CRITICAL or HIGH
+vulnerabilites are found.  Trivy is also run daily to check for new
+vulnerabilities in existing images.  So periodic review of new findings
+is needed:  Go to the Security tab in GitHub, select Code Scanning at left,
+and then select Branch > Main to check for new findings.  To suppress
+findings which are not "true positives", either:
+
+- Enter the CVE in `.trivyignore`, or
+
+- Enter the file to skip while scanning in the `trivy.yml` workflow.
+
+In either case, add a comment to explain why the finding is suppressd.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ${DOCKER_IMAGE}
 
 ## Security
 
-Trivy is run on each built container and they will not be published 
+Trivy is run on each built container and they will not be published
 to `ghcr.io` if any CRITICAL or HIGH
 vulnerabilites are found.  Trivy is also run daily to check for new
 vulnerabilities in existing images.  So periodic review of new findings

--- a/README.md
+++ b/README.md
@@ -107,16 +107,16 @@ ${DOCKER_IMAGE}
 
 ## Security
 
-Trivy is run on each built container, to scan for known vulnerabilities.
-Containers will not be published to `ghcr.io` if any CRITICAL or HIGH
+Trivy is run on each built container and they will not be published 
+to `ghcr.io` if any CRITICAL or HIGH
 vulnerabilites are found.  Trivy is also run daily to check for new
 vulnerabilities in existing images.  So periodic review of new findings
 is needed:  Go to the Security tab in GitHub, select Code Scanning at left,
 and then select Branch > Main to check for new findings.  To suppress
-findings which are not "true positives", either:
+false positives, either:
 
 - Enter the CVE in `.trivyignore`, or
 
 - Enter the file to skip while scanning in the `trivy.yml` workflow.
 
-In either case, add a comment to explain why the finding is suppressd.
+In either case, add a comment justifying why the finding is suppressd.


### PR DESCRIPTION
This PR adds vulnerability scanning to the repo' using Trivy.
The workflow to build and publish a container will fail if there are HIGH or CRITICAL findings.
There is also a daily scan to see if there are new, major vulnerabilities for already published containers.
When a container image IS published, in addition to being published to the tag major.minor.patch,
it is published to the tag major.minor.  This allows us to make security updates to existing containers.