### PR TITLE
IT-3921 Add automated image update to fix Trivy findings

### DIFF
--- a/.dockerfilelintrc
+++ b/.dockerfilelintrc
@@ -1,3 +1,4 @@
 rules:
   apt-get_missing_rm: off
   apt-get_recommends: off
+  apt-get-upgrade: off

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -85,4 +85,7 @@ jobs:
           sarif_file: ${{ env.sarif_file_name  }}
           category: ${{ inputs.NOTEBOOK_TYPE }}
           wait-for-processing: true
+
+    outputs:
+      trivy_conclusion: steps.trivy.outputs.conclusion
 ...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,6 +30,11 @@ on:
 
 env:
   sarif_file_name: trivy-results-${{ inputs.NOTEBOOK_TYPE  }}.sarif
+  # downloading the trivy-db from its default GitHub location fails because
+  # the site experiences too many downloads.  The fix is to pull from this
+  # alternate location.
+  TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+  TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
 jobs:
   trivy:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -41,4 +41,17 @@ jobs:
       # Docker images can only be lower case
       IMAGE_NAME: ghcr.io/${{ needs.to-lower-case.outputs.lowercase-repo-name
             }}-${{ matrix.notebook_type }}:main
+
+  # If scan failed, rebuild the image
+  update-image:
+    if: ${{needs.trivy-matrix.outputs.trivy_conclusion == 'failure' }}
+    needs: trivy-matrix
+    runs-on: ubuntu-latest
+    # tag the repo to trigger a new build
+    steps:
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -44,7 +44,7 @@ jobs:
 
   # If scan failed, rebuild the image
   update-image:
-    if: ${{needs.trivy-matrix.outputs.trivy_conclusion == 'failure' }}
+    if: ${{!cancelled() && needs.trivy-matrix.outputs.trivy_conclusion == 'failure' }}
     needs: trivy-matrix
     runs-on: ubuntu-latest
     # tag the repo to trigger a new build

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 80
+    level: warning

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG notebook_type=jupyter
 
 # Update the repository sources list and install apache
 RUN apt-get update && \
+apt-get -y upgrade && \
 apt-get install -y python3-dev git unzip apache2 apache2-dev curl pip && apt-get clean
 
 # patterned after https://github.com/Sage-Bionetworks-IT/packer-rstudio/blob/master/src/playbook.yaml#L76-L91


### PR DESCRIPTION
- add `apt-get upgrade` to Dockerfile to update dependencies upon build;
- add job to periodic scan which tags `main` with a new tag if Trivy produces findings; This will trigger a new build;
- download vul'n DBs from ECR rather than from GHCR to avoid throttling