### PR TITLE
[IT-4003] Auto-update pre-commit hook versions monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 ---
+ci:
+  autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/awslabs/git-secrets
     rev: b9e96b3212fa06aea65964ff0d5cda84ce935f38


### PR DESCRIPTION
Change the frequency that PRs to update pre-commit hook versions are auto-generated from weekly (the default) to monthly.