### PR TITLE
IT-3921: Fix periodic scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -27,7 +27,10 @@ on:
         required: false
         type: number
         default: 0
-
+    outputs:
+      trivy_conclusion:
+        description: "The pass/fail return code from Trivy"
+        value: ${{ jobs.trivy.outputs.trivy_conclusion }}
 env:
   sarif_file_name: trivy-results-${{ inputs.NOTEBOOK_TYPE  }}.sarif
   # downloading the trivy-db from its default GitHub location fails because
@@ -92,5 +95,5 @@ jobs:
           wait-for-processing: true
 
     outputs:
-      trivy_conclusion: steps.trivy.outputs.conclusion
+      trivy_conclusion: steps.trivy.conclusion
 ...


### PR DESCRIPTION
Two fixes:
(1) When referring to the output of a callable workflow we have to reference the output of the workflow not of a job in the workflow.  This PR adds the workflow output, `trivy_conclusion` so it can be referenced by the caller;
(2) When referring to the `conclusion` of a step it's `step.conclusion` not `step.output.conclusion`.