### PR TITLE
Update workflow to rebuild image after Trivy failure

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -90,7 +90,7 @@ jobs:
           # comma separated list of tags
           tag_list=${{ inputs.TAGS }}
           # prepend each tag with repo name, e.g., "tag1"->"reponame:tag1"; "tag1,tag2"->"reponame:tag1,reponame:tag2"
-          image_references=$repo_name:${tag_list/,/,$repo_name:}
+          image_references=$repo_name:${tag_list//,/,$repo_name:}
           echo "image_references=$image_references" >> $GITHUB_ENV
 
       - name: Build and push Docker image

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -12,31 +12,27 @@ on:
       NOTEBOOK_TYPE:
         required: true
         type: string
+      REF_TO_CHECKOUT:
+        required: false
+        type: string
+        description: reference to checkout, e.g. a tag like v1.0.1.  Defaults to the branch/tag of the current event.
+      TAGS:
+        required: true
+        type: string
+        description: "comma delimited list of tags, e.g., 2.3.4, or main,1.0,1.0.1"
 
 env:
-  IMAGE_PATH: ghcr.io/${{ github.repository }}-${{ inputs.NOTEBOOK_TYPE }}
   TARFILE_NAME: ${{ inputs.NOTEBOOK_TYPE }}-image.tar
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4.1.1
         with:
-          images: ${{ env.IMAGE_PATH }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}} # major.minor.patch
-            type=semver,pattern={{major}}.{{minor}}
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
 
       - name: Build Docker image for scanning, but don't push to ghcr.io yet
         uses: docker/build-push-action@v6.4.0
@@ -45,8 +41,6 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           push: false
           outputs: type=tar,dest=${{ env.TARFILE_NAME }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Upload tarball for use by Trivy job
         uses: actions/upload-artifact@v4
@@ -55,28 +49,25 @@ jobs:
           path: ${{ env.TARFILE_NAME }}
 
     outputs:
-      meta_json: ${{ steps.meta.outputs.json }}
       tarfile_artifact: ${{ env.TARFILE_NAME }}
 
   trivy-scan:
-    needs: build
+    needs: tests
     uses: "./.github/workflows/trivy.yml"
     with:
       NOTEBOOK_TYPE: ${{ inputs.NOTEBOOK_TYPE }}
       SOURCE_TYPE: tar
       IMAGE_NAME: image-name
-      TARFILE_NAME: ${{ needs.build.outputs.tarfile_artifact }}
+      TARFILE_NAME: ${{ needs.tests.outputs.tarfile_artifact }}
       EXIT_CODE: 1
 
   push-image:
-    needs: [build, trivy-scan]
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    needs: [tests, trivy-scan]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    strategy:
-      matrix:
-        value: ${{ fromJSON(needs.build.outputs.meta_json).tags }}
 
     steps:
       - name: Login to GitHub Container Registry
@@ -88,6 +79,19 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
+
+      - name: Prepend image references with repo' names to produce image references
+        id: image_references
+        run: |
+          # convert repo' name to lower case to be used as a Docker name
+          repo_name=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-${{ inputs.NOTEBOOK_TYPE }}
+          # comma separated list of tags
+          tag_list=${{ inputs.TAGS }}
+          # prepend each tag with repo name, e.g., "tag1"->"reponame:tag1"; "tag1,tag2"->"reponame:tag1,reponame:tag2"
+          image_references=$repo_name:${tag_list/,/,$repo_name:}
+          echo "image_references=$image_references" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.4.0
@@ -95,5 +99,5 @@ jobs:
           build-args: notebook_type=${{ inputs.NOTEBOOK_TYPE }}
           context: .
           push: true
-          tags: ${{ matrix.value }}
+          tags: ${{ env.image_references }}
 ...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 ---
-name: Run tests and conditionally build container
+name: Determine the Docker 'tags' to use, then invoke the build/test/publish workflow.
 
 on:
   push:
@@ -13,40 +13,45 @@ on:
 
 jobs:
   tests:
+    uses: "./.github/workflows/test.yml"
+
+  get-tags:
     runs-on: ubuntu-latest
+    needs: [tests]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Static Analysis
-        uses: pre-commit/action@v3.0.0
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v6.4.0
+      - name: Convert repo' name to lower case
+        id: to_lower_case
+        run: |
+          # While GitHub repo's can be mixed (upper and lower) case,
+          # Docker images can only be lower case
+          repo_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+          echo "repo_name=$repo_name" >> $GITHUB_ENV
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.1.1
         with:
-          context: .
-          build-args: notebook_type=jupyter
-          push: false
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}} # major.minor.patch
+            type=semver,pattern={{major}}.{{minor}}
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt -r requirements-dev.txt
+    outputs:
+      image_repo: ghcr.io/${{ env.repo_name }}
+      tags: ${{ steps.meta.outputs.tags }}
 
-      - name: Run unit tests
-        run: python -m pytest tests/ -s -v
-
-  docker-build-push-jupyter:
+  docker-build-push:
     if: ${{ github.event_name == 'push' }}
-    needs: [tests]
+    needs: [get-tags]
     uses: "./.github/workflows/docker_build_push.yml"
+    strategy:
+      matrix:
+        notebook_type:
+          - jupyter
+          - rstudio
+
     secrets: inherit
     with:
-      NOTEBOOK_TYPE: jupyter
-
-  docker-build-push-rstudio:
-    if: ${{ github.event_name == 'push' }}
-    needs: [tests]
-    uses: "./.github/workflows/docker_build_push.yml"
-    secrets: inherit
-    with:
-      NOTEBOOK_TYPE: rstudio
+      TAGS: ${{ needs.get-tags.outputs.tags }}
+      NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
 ...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches:
       - '*'
+env:
+  TAG_PREFIX: PREFIX
 
 jobs:
   tests:
@@ -30,16 +32,26 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:
-          images: |
+          images: ${{ env.TAG_PREFIX }} # dummy value since blank is not allowed
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}} # major.minor.patch
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: Remove dummy prefix
+        id: removed
+        run: |
+          # comma separated list of tags
+          reference_list=${{ steps.meta.outputs.tags }}
+          prefix_to_remove=${{ env.TAG_PREFIX }}:
+          # remove prefix, e.g., ->"PREFIX:tag1,PREFIX:tag2"->"tag1,tag2"
+          tags=${reference_list//$prefix_to_remove/}
+          echo "tags=$tags" >> $GITHUB_ENV
+
     outputs:
       image_repo: ghcr.io/${{ env.repo_name }}
-      tags: ${{ steps.meta.outputs.tags }}
+      tags: ${{ env.tags }}
 
   docker-build-push:
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:
-          images: ""
+          images: []
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:
-          images: []
+          images: |
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,12 +37,9 @@ jobs:
         run: |
           # comma separated list of tags
           reference_list=${{ steps.meta.outputs.tags }}
-          echo reference_list $reference_list
           prefix_to_remove=${{ env.TAG_PREFIX }}:
-          echo prefix_to_remove $prefix_to_remove
           # remove prefix, e.g., ->"prefix:tag1,prefix:tag2"->"tag1,tag2"
           tags=${reference_list//$prefix_to_remove/}
-          echo tags $tags
           echo "tags=$tags" >> $GITHUB_ENV
 
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,12 @@ jobs:
         run: |
           # comma separated list of tags
           reference_list=${{ steps.meta.outputs.tags }}
+          echo reference_list $reference_list
           prefix_to_remove=${{ env.TAG_PREFIX }}:
+          echo prefix_to_remove $prefix_to_remove
           # remove prefix, e.g., ->"PREFIX:tag1,PREFIX:tag2"->"tag1,tag2"
           tags=${reference_list//$prefix_to_remove/}
+          echo tags $tags
           echo "tags=$tags" >> $GITHUB_ENV
 
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:
-          images:
+          images: ""
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.1.1
         with:
+          images:
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - '*'
 env:
-  TAG_PREFIX: PREFIX
+  TAG_PREFIX: prefix # must be lower case
 
 jobs:
   tests:
@@ -21,13 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests]
     steps:
-      - name: Convert repo' name to lower case
-        id: to_lower_case
-        run: |
-          # While GitHub repo's can be mixed (upper and lower) case,
-          # Docker images can only be lower case
-          repo_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
-          echo "repo_name=$repo_name" >> $GITHUB_ENV
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4.1.1
@@ -47,13 +40,12 @@ jobs:
           echo reference_list $reference_list
           prefix_to_remove=${{ env.TAG_PREFIX }}:
           echo prefix_to_remove $prefix_to_remove
-          # remove prefix, e.g., ->"PREFIX:tag1,PREFIX:tag2"->"tag1,tag2"
+          # remove prefix, e.g., ->"prefix:tag1,prefix:tag2"->"tag1,tag2"
           tags=${reference_list//$prefix_to_remove/}
           echo tags $tags
           echo "tags=$tags" >> $GITHUB_ENV
 
     outputs:
-      image_repo: ghcr.io/${{ env.repo_name }}
       tags: ${{ env.tags }}
 
   docker-build-push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+---
+#
+# Run static analysis, verify that image will build, and run tests
+#
+name: Build and publish a Docker image
+
+on:
+  workflow_call:
+    inputs:
+      REF_TO_CHECKOUT:
+        required: false
+        type: string
+        description: reference to checkout, e.g. a tag like v1.0.1.  Defaults to the branch/tag of the current event.
+    outputs:
+      conclusion:
+        value: ${{ jobs.tests.outputs.conclusion }}
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
+
+      - name: Static Analysis
+        uses: pre-commit/action@v3.0.0
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v6.4.0
+        with:
+          context: .
+          build-args: notebook_type=jupyter
+          push: false
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run unit tests
+        id: unit_tests
+        run: python -m pytest tests/ -s -v
+
+
+    outputs:
+      conclusion: ${{ steps.unit_tests.conclusion }}
+...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,14 +23,15 @@ on:
       IMAGE_NAME:
         required: true
         type: string
-      EXIT_CODE: # return code for failed scan. 0 means OK
+      EXIT_CODE: # return code for failed scan. 0 means OK.  Non-zero will fail the build when there are findings.
         required: false
         type: number
         default: 0
     outputs:
       trivy_conclusion:
-        description: "The pass/fail return code from Trivy"
+        description: "The pass/fail status from Trivy"
         value: ${{ jobs.trivy.outputs.trivy_conclusion }}
+
 env:
   sarif_file_name: trivy-results-${{ inputs.NOTEBOOK_TYPE  }}.sarif
   # downloading the trivy-db from its default GitHub location fails because
@@ -66,7 +67,7 @@ jobs:
           }} | docker import - ${{ inputs.IMAGE_NAME }}
 
       - name: Run Trivy vulnerability scanner for any major issues
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.28.0
         id: trivy
         with:
           image-ref: ${{ inputs.IMAGE_NAME }}
@@ -88,6 +89,10 @@ jobs:
         # after Trivy exits with HIGH/CRITICAL findings
         # See https://github.com/aquasecurity/trivy-action?\
         # tab=readme-ov-file#using-trivy-with-github-code-scanning
+        # Note that here instead of using `always()` which would
+        # allow the step to run if *any* preceeding step failed,
+        # this logic ensures that the step ony runs if all steps
+        # succeed or if only  the 'trivy' step fails.
         if: ${{ success() || steps.trivy.conclusion=='failure' }}
         with:
           sarif_file: ${{ env.sarif_file_name  }}
@@ -95,5 +100,5 @@ jobs:
           wait-for-processing: true
 
     outputs:
-      trivy_conclusion: steps.trivy.conclusion
+      trivy_conclusion: ${{ steps.trivy.conclusion }}
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -2,8 +2,6 @@
 #
 # This workflow scans the published container images
 # for new vulnerabilities daily, publishing findings.
-# Findings will be associated with the 'main' branch
-# of the repo' in the GitHub Security tab.
 #
 name: Trivy Periodic Image Scan
 
@@ -13,21 +11,29 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  to-lower-case:
+  get-image-reference:
     runs-on: ubuntu-latest
-    name: to-lower-case
     steps:
-      - name: Ensure repo' name is lower case
-        id: repo
-        uses: vishalmamidi/lowercase-action@v1
+      - name: Convert repo' name to lower case
+        id: to_lower_case
+        run: |
+          # While GitHub repo's can be mixed (upper and lower) case,
+          # Docker images can only be lower case
+          repo_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+          echo "repo_name=$repo_name" >> $GITHUB_ENV
+      - name: Find current version
+        id: find_version
+        uses: mathieudutour/github-tag-action@v6.2
         with:
-          string: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true # setting to 'true' means no new version is created
     outputs:
-      lowercase-repo-name: ${{ steps.repo.outputs.lowercase }}
+      image_repo: ghcr.io/${{ env.repo_name }}
+      image_tag: ${{ steps.find_version.outputs.previous_version }}
 
   trivy-matrix:
-    name: trivy-${{ matrix.notebook_type }}
-    needs: to-lower-case
+    name: trivy
+    needs: [get-image-reference]
     strategy:
       matrix:
         notebook_type:
@@ -37,16 +43,15 @@ jobs:
     with:
       NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
       SOURCE_TYPE: image
-      # While GitHub repo's can be mixed (upper and lower) case,
-      # Docker images can only be lower case
-      IMAGE_NAME: ghcr.io/${{ needs.to-lower-case.outputs.lowercase-repo-name
-            }}-${{ matrix.notebook_type }}:main
+      IMAGE_NAME: ghcr.io/${{ needs.get-image-reference.outputs.image_repo
+            }}-${{ matrix.notebook_type }}:${{ needs.get-image-reference.outputs.image_tag }}
+      EXIT_CODE: 1
 
-  # If scan failed, rebuild the image
-  update-image:
-    if: ${{!cancelled() && needs.trivy-matrix.outputs.trivy_conclusion == 'failure' }}
+  # If scan failed, bump tag and rebuild the image
+  bump-tag:
     needs: trivy-matrix
     runs-on: ubuntu-latest
+    if: ${{!cancelled() && needs.trivy-matrix.outputs.trivy_conclusion == 'failure' }}
     # tag the repo to trigger a new build
     steps:
       - name: Bump version and push tag
@@ -54,4 +59,36 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: parse new version
+        id: parsed
+        uses: booxmedialtd/ws-action-parse-semver@v1
+        with:
+          input_string: ${{ steps.tag_version.outputs.new_version }}
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      new_version: ${{ steps.tag_version.outputs.new_version }}
+      new_major_minor: ${{ steps.parsed.outputs.major }}.${{ steps.parsed.outputs.minor }}
+      conclusion: ${{ steps.parsed.conclusion }}
+
+  tests:
+    needs: [trivy-matrix, bump-tag]
+    if: ${{!cancelled() && needs.trivy-matrix.outputs.trivy_conclusion == 'failure' &&
+      needs.bump-tag.outputs.conclusion == 'success' }}
+    uses: "./.github/workflows/test.yml"
+
+  update-image:
+    needs: [trivy-matrix, tests]
+    if: ${{!cancelled() && needs.trivy-matrix.outputs.trivy_conclusion == 'failure' &&
+      needs.tests.outputs.conclusion == 'success' }}
+    strategy:
+      matrix:
+        notebook_type:
+          - jupyter
+          - rstudio
+    uses: "./.github/workflows/docker_build_push.yml"
+    with:
+      NOTEBOOK_TYPE: ${{ matrix.notebook_type }}
+      REF_TO_CHECKOUT: ${{ needs.bump-tag.outputs.new_tag }}
+      TAGS: "${{ needs.bump-tag.outputs.new_version }},\
+        ${{ needs.bump-tag.outputs.new_major_minor }}"
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -77,8 +77,9 @@ jobs:
     uses: "./.github/workflows/test.yml"
 
   update-image:
-    needs: [trivy-matrix, tests]
+    needs: [trivy-matrix, bump-tag, tests]
     if: ${{!cancelled() && needs.trivy-matrix.outputs.trivy_conclusion == 'failure' &&
+      needs.bump-tag.outputs.conclusion == 'success'  &&
       needs.tests.outputs.conclusion == 'success' }}
     strategy:
       matrix:


### PR DESCRIPTION
When a daily Trivy security scan fails, we want to generate a new patch version (say, advance from 1.1.2 to 1.1.3), build and test that version then, if the new version passes Trivy, publish the Docker image.

Previously the daily scan simply scanned the main Docker tag (which was built from the head of the main branch), but this isn't quite right, since the head of main might be different from the latest tag (1.1.2). So we added the get-image-reference job to `trivy_periodic_image_scan.yml` to find the latest tag, which we then use to determine what container image to scan.

When a Trivy scan fails we create a new tag. We expected the new tag to kick off a new build, but GitHub does not allow events generated in a workflow to trigger another workflow. (This is to avoid infinite loops.) So we need to explicitly invoke the docker_build_push.yml workflow. To do this we refactored the workflow so that it can be called either by a PR or merge (from the new main.yml entrypoint) or from the trivy_periodic_image_scan.yml entrypoint. Each entrypoint determines (1) what GitHub tag to checkout and (2) what Docker tags to publish to, and passes them along to the docker_build_push.yml workflow.

Before building an image we want to peform static analysis and run unit tests.  Since this step must precede the PR/merge-triggered build and the Trivy-triggered image rebuild, we factored it out into `test.yml` so it can be called both from `main.yml` and `trivy_periodic_image_scan.yml`.